### PR TITLE
Fix thanos-rule container volumeMounts

### DIFF
--- a/thanos-rule-template/thanos-rule-patch.yaml
+++ b/thanos-rule-template/thanos-rule-patch.yaml
@@ -25,12 +25,10 @@ spec:
       containers:
         - name: thanos-rule
           volumeMounts:
-            - $patch: delete
-              name: rules
             - name: rules-rendered
               mountPath: /var/thanos/rules
       volumes:
-        # $patch: delete doesn't seem to work here, so dropping the upstream
+        # $patch: replace doesn't seem to work here, so dropping the upstream
         # rules volume completely and using a new one for rendered alerts.
         - $patch: delete
           name: rules


### PR DESCRIPTION
`$patch: delete` actually drops the whole list and does not match a mount by name. Seems like all we need to do is specify the mount for our rules-rendered volume.