### PR TITLE
Increase windown before alerting for cfssl instances

### DIFF
--- a/common/all.yaml.tmpl
+++ b/common/all.yaml.tmpl
@@ -156,11 +156,11 @@ groups:
           summary: "{{ $labels.instance }} instance has a read only root filesystem for 5m"
       - alert: CfsslDown
         expr: probe_success{job="cfssl-probe"} == 0 or absent(probe_success{job="cfssl-probe"})
-        for: 5m
+        for: 10m
         labels:
           team: infra
         annotations:
-          summary: "{{ $labels.instance }} reports down more than 5 minutes."
+          summary: "{{ $labels.instance }} reports down more than 10 minutes."
       - alert: VolumeDiskUsage
         expr: kubelet_volume_stats_used_bytes / kubelet_volume_stats_capacity_bytes * on(namespace) group_left kube_namespace_labels{label_uw_systems_owner="system"} > 0.9
         for: 5m


### PR DESCRIPTION
We need more time to roll merit nodes and for cfssl instances we can be more relaxed than 5 minutes before alerting. This doubles the window before firing