### PR TITLE
Alert only on important systemd units

### DIFF
--- a/common/all.yaml.tmpl
+++ b/common/all.yaml.tmpl
@@ -490,13 +490,13 @@ groups:
           description: "{{ $labels.instance }} reports down more than 10 minutes."
           summary: Wiresteward node exporter job down
       - alert: WirestewardSystemdServiceDown
-        expr: node_systemd_units{state="failed", instance=~"^\\d\\.private-wiresteward.+$"} != 0
+        expr: node_systemd_units{state="failed", name=~"s3fs.service|wiresteward.service", instance=~"^\\d\\.private-wiresteward.+$"} != 0
         for: 10m
         labels:
           team: infra
         annotations:
           description: "{{ $labels.instance }} reports systemd services down more than 10 minutes."
-          summary: Wiresteward node has failed systemd services
+          summary: Wiresteward node has failed important systemd services
   - name: semaphore
     rules:
       - alert: SemaphorePolicyCalicoClientErrors


### PR DESCRIPTION
The unit `systemd-udev-settle.service` fails sometimes on boot but doesn't seem to cause any issues. So alerting instead on the s3fs unit, which was the original reason to include this alert (commit ba138024c186bc6aaca64d815263ac767b5594a9 and https://trello.com/c/kx72Xyd2/1881-alert-on-wiresteward-s3fs-issues) and wiresteward.