### PR TITLE
Strip only .tmpl and .tpl extensions

### DIFF
--- a/thanos-rule-template/thanos-rule-patch.yaml
+++ b/thanos-rule-template/thanos-rule-patch.yaml
@@ -15,9 +15,10 @@ spec:
             - -c
             - |
               apk add --no-cache gettext;
-              for file in $(ls /var/thanos/rule-templates/*/*.tmpl); do
-                f=$(basename $file);
-                envsubst '${ENVIRONMENT},${PROVIDER}' < $file > /var/thanos/rules/${f%.*};
+              for file in $(find /var/thanos/rule-templates/ -type f); do
+                # If the file has a .tmpl or .tpl extension - remove it
+                [ "$f" = "${f%.tmpl}" -o "$f" = "${f%.tpl}" ] && f="${f%.tmpl}" && f="${f%.tpl}"
+                envsubst '${ENVIRONMENT},${PROVIDER}' < $file > /var/thanos/rules/$(basename $f);
               done;
           volumeMounts:
             - name: rules-rendered


### PR DESCRIPTION
This means:

- We can re-use this component for sys-mon logic (where we run envsubst
  over .yaml files)
- We won't accidentally strip some other extension by accident
- Run envsubst over *all* files - this brings logic parity with current
  sys-mon implementation
