### PR TITLE
add app_uw_systems annotations to replica stock alerts

### DIFF
--- a/common/stock/missing_replicas.yaml.tmpl
+++ b/common/stock/missing_replicas.yaml.tmpl
@@ -5,7 +5,7 @@ groups:
   - name: MissingReplicas
     rules:
       - alert: DeploymentMissingReplicas
-        expr: kube_deployment_status_replicas_available != kube_deployment_status_replicas
+        expr: (kube_deployment_spec_replicas != kube_deployment_status_replicas_available) * ON (deployment, namespace) group_left(annotation_app_uw_systems_tier, annotation_app_uw_systems_system, annotation_app_uw_systems_owner) kube_deployment_annotations{}
         for: 15m
         labels:
           group: missing_replicas
@@ -15,7 +15,7 @@ groups:
           action: "Check why some replicas are not healthy"
           command: "kubectl --context $ENVIRONMENT-$PROVIDER --namespace {{ $labels.namespace }} describe deployment {{ $labels.deployment }}"
       - alert: StatefulsetMissingReplicas
-        expr: kube_statefulset_status_replicas_ready != kube_statefulset_status_replicas
+        expr: (kube_statefulset_status_replicas_ready != kube_statefulset_status_replicas) * ON (statefulset, namespace) group_left(annotation_app_uw_systems_tier, annotation_app_uw_systems_system, annotation_app_uw_systems_owner) kube_statefulset_annotations{}
         for: 15m
         labels:
           group: missing_replicas
@@ -36,7 +36,7 @@ groups:
           action: "Check why some replicas are not healthy"
           command: "kubectl --context $ENVIRONMENT-$PROVIDER --namespace {{ $labels.namespace }} describe daemonset {{ $labels.daemonset }}"
       - alert: DeploymentMissingAllReplicas
-        expr: kube_deployment_status_replicas_available == 0 and kube_deployment_status_replicas != 0
+        expr: (kube_deployment_status_replicas_available == 0 and kube_deployment_status_replicas != 0) * ON (deployment, namespace) group_left(annotation_app_uw_systems_tier, annotation_app_uw_systems_system, annotation_app_uw_systems_owner) kube_deployment_annotations{}
         for: 5m
         labels:
           group: missing_replicas
@@ -46,7 +46,7 @@ groups:
           action: "Check why all replicas are missing"
           command: "kubectl --context $ENVIRONMENT-$PROVIDER --namespace {{ $labels.namespace }} describe deployment {{ $labels.deployment }}"
       - alert: StatefulsetMissingAllReplicas
-        expr: kube_statefulset_status_replicas_ready == 0 and kube_statefulset_status_replicas != 0
+        expr: (kube_statefulset_status_replicas_ready == 0 and kube_statefulset_status_replicas != 0) * ON (statefulset, namespace) group_left(annotation_app_uw_systems_tier, annotation_app_uw_systems_system, annotation_app_uw_systems_owner) kube_statefulset_annotations{}
         for: 5m
         labels:
           group: missing_replicas
@@ -56,7 +56,7 @@ groups:
           action: "Check why all replicas are missing"
           command: "kubectl --context $ENVIRONMENT-$PROVIDER --namespace {{ $labels.namespace }} describe statefulset {{ $labels.statefulset }}"
       - alert: DaemonsetMissingAllReplicas
-        expr: kube_daemonset_status_number_ready == 0 and kube_daemonset_status_desired_number_scheduled != 0
+        expr: (kube_daemonset_status_number_ready == 0 and kube_daemonset_status_desired_number_scheduled != 0)
         for: 5m
         labels:
           group: missing_replicas


### PR DESCRIPTION
This is a proposal and a request for comments on including `tier`, `system` and `owner`[^owner] information (`app_uw_systems` annotations) in stock alerts.

All alerts are important, and the goal of the inclusion of tier, system and owner is to allow us to provide better escalation policy for business hours and out of hours support depending on the impact.

Have not included `Deamonset` in the changes because there are no annotations whitelisted for this resource at this time [link](https://thanos.prod.aws.uw.systems/graph?g0.expr=kube_daemonset_annotations%7B%7D&g0.tab=0&g0.stacked=0&g0.range_input=1h&g0.max_source_resolution=0s&g0.deduplicate=1&g0.partial_response=0&g0.store_matches=%5B%5D&g0.engine=thanos&g0.explain=0)

[^owner]: I'm not sure if we should be including `owner` annotations so please let me know if you oppose.

