### PR TITLE
use keep_firing_for to prevent flappy alerts

### DIFF
--- a/common/stock/missing_replicas.yaml.tmpl
+++ b/common/stock/missing_replicas.yaml.tmpl
@@ -6,6 +6,7 @@ groups:
     rules:
       - alert: DeploymentMissingReplicas
         expr: (kube_deployment_spec_replicas != kube_deployment_status_replicas_available) * ON (deployment, namespace) group_left(annotation_app_uw_systems_tier, annotation_app_uw_systems_system, annotation_app_uw_systems_owner) kube_deployment_annotations{}
+        keep_firing_for: 5m
         for: 15m
         labels:
           group: missing_replicas
@@ -16,6 +17,7 @@ groups:
           command: "kubectl --context $ENVIRONMENT-$PROVIDER --namespace {{ $labels.namespace }} describe deployment {{ $labels.deployment }}"
       - alert: StatefulsetMissingReplicas
         expr: (kube_statefulset_status_replicas_ready != kube_statefulset_status_replicas) * ON (statefulset, namespace) group_left(annotation_app_uw_systems_tier, annotation_app_uw_systems_system, annotation_app_uw_systems_owner) kube_statefulset_annotations{}
+        keep_firing_for: 5m
         for: 15m
         labels:
           group: missing_replicas
@@ -27,6 +29,7 @@ groups:
       - alert: DaemonsetMissingReplicas
         # Alert if there are unhealthy replicas and the ds is not updating it's replicas
         expr: (kube_daemonset_status_number_ready != kube_daemonset_status_desired_number_scheduled) and changes(kube_daemonset_status_updated_number_scheduled[10m]) == 0
+        keep_firing_for: 2m
         for: 5m
         labels:
           group: missing_replicas
@@ -37,6 +40,7 @@ groups:
           command: "kubectl --context $ENVIRONMENT-$PROVIDER --namespace {{ $labels.namespace }} describe daemonset {{ $labels.daemonset }}"
       - alert: DeploymentMissingAllReplicas
         expr: (kube_deployment_status_replicas_available == 0 and kube_deployment_status_replicas != 0) * ON (deployment, namespace) group_left(annotation_app_uw_systems_tier, annotation_app_uw_systems_system, annotation_app_uw_systems_owner) kube_deployment_annotations{}
+        keep_firing_for: 2m
         for: 5m
         labels:
           group: missing_replicas
@@ -47,6 +51,7 @@ groups:
           command: "kubectl --context $ENVIRONMENT-$PROVIDER --namespace {{ $labels.namespace }} describe deployment {{ $labels.deployment }}"
       - alert: StatefulsetMissingAllReplicas
         expr: (kube_statefulset_status_replicas_ready == 0 and kube_statefulset_status_replicas != 0) * ON (statefulset, namespace) group_left(annotation_app_uw_systems_tier, annotation_app_uw_systems_system, annotation_app_uw_systems_owner) kube_statefulset_annotations{}
+        keep_firing_for: 2m
         for: 5m
         labels:
           group: missing_replicas
@@ -57,6 +62,7 @@ groups:
           command: "kubectl --context $ENVIRONMENT-$PROVIDER --namespace {{ $labels.namespace }} describe statefulset {{ $labels.statefulset }}"
       - alert: DaemonsetMissingAllReplicas
         expr: (kube_daemonset_status_number_ready == 0 and kube_daemonset_status_desired_number_scheduled != 0)
+        keep_firing_for: 2m
         for: 5m
         labels:
           group: missing_replicas


### PR DESCRIPTION
Proposition to use `keep_firing_for` in missing replicas alerts to reduce alert flapping.
 
Address situations where replica sets become available for a short time periods.

[Example](https://thanos-query-sys-prom.dev.merit.uw.systems/graph?g0.expr=ALERTS%7Balertname%3D%22DeploymentMissingReplicas%22%2C%20namespace%3D%22partner%22%2C%20deployment%3D%22upline-calculator%22%7D&g0.tab=0&g0.stacked=0&g0.range_input=1h&g0.max_source_resolution=0s&g0.deduplicate=1&g0.partial_response=0&g0.store_matches=%5B%5D&g0.engine=thanos&g0.explain=0&g1.expr=kube_deployment_spec_replicas%7Bnamespace%3D%22partner%22%2C%20deployment%3D%22upline-calculator%22%7D%20!%3D%20kube_deployment_status_replicas_available%7Bnamespace%3D%22partner%22%2C%20deployment%3D%22upline-calculator%22%7D&g1.tab=0&g1.stacked=0&g1.range_input=1h&g1.max_source_resolution=0s&g1.deduplicate=1&g1.partial_response=0&g1.store_matches=%5B%5D&g1.engine=thanos&g1.explain=0)
![flappy](https://github.com/utilitywarehouse/system-alerts/assets/3635582/c51709f0-a06a-4452-bc14-a69b6e4fd07a)
