### PR TITLE
Set longer period for the container crashing expr

### DIFF
--- a/common/stock/container.yaml.tmpl
+++ b/common/stock/container.yaml.tmpl
@@ -4,19 +4,20 @@
 groups:
   - name: Container
     rules:
+      # Set period to 2h to capture slow crashing containers like
+      # thanos-compact that take a long time to start up
       - alert: ContainerRestartingOften
-        expr: increase(kube_pod_container_status_restarts_total[10m]) > 3
-        keep_firing_for: 10m
+        expr: increase(kube_pod_container_status_restarts_total[2h]) > 3
         labels:
           group: container
         annotations:
-          summary: "Container {{$labels.namespace}}/{{$labels.pod}}/{{$labels.container}} has restarted more than 3 times in the last 10m"
+          summary: "Container {{$labels.namespace}}/{{$labels.pod}}/{{$labels.container}} has restarted more than 3 times in the last 2h"
           impact: "Container may be crashlooping and not working as expected"
           action: "Check pod status and container logs to figure out if there's a problem"
           command: "kubectl --context $ENVIRONMENT-$PROVIDER --namespace {{ $labels.namespace }} describe pod {{ $labels.pod }}"
           logs: "https://grafana.$ENVIRONMENT.aws.uw.systems/explore?orgId=1&left=%7B%22datasource%22%3A%22P8E80F9AEF21F6940%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22expr%22%3A%22%7Bkubernetes_cluster%3D%5C%22$ENVIRONMENT-$PROVIDER%5C%22%2C+kubernetes_namespace%3D%5C%22{{ $labels.namespace }}%5C%22%2C+app_kubernetes_io_name%3D%5C%{{ $labels.label_app_kubernetes_io_name }}%5C%22%7D%22%2C%22queryType%22%3A%22range%22%2C%22datasource%22%3A%7B%22type%22%3A%22loki%22%2C%22uid%22%3A%22P8E80F9AEF21F6940%22%7D%2C%22editorMode%22%3A%22code%22%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-1h%22%2C%22to%22%3A%22now%22%7D%7D"
+      # https://github.com/kubernetes-monitoring/kubernetes-mixin/issues/108#issuecomment-432796867
       - alert: ContainerCpuThrottled
-        # https://github.com/kubernetes-monitoring/kubernetes-mixin/issues/108#issuecomment-432796867
         expr: sum(increase(container_cpu_cfs_throttled_periods_total[5m])) by (container, pod, namespace) / sum(increase(container_cpu_cfs_periods_total[5m])) by (container, pod, namespace) > 0.95
         for: 15m
         labels:


### PR DESCRIPTION
Containers like "thanos-compact" can have long start up times, and
therefore take a long time between crashes. Set a longer period so that
we can capture this scenario.
