### PR TITLE
Split DaemonSet alerts out of stock

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ downstream:
 
 - ENVIRONMENT: exp-1|dev|prod
 - PROVIDER: aws|gcp|merit
+- NODE_ROLL_WINDOW: Expected time we need a node to reboot so we do not trigger DS alerts
 
 # How to use it
 
@@ -60,6 +61,8 @@ spec:
               value: exp-1
             - name: PROVIDER
               value: aws
+            - name: NODE_ROLL_WINDOW
+              value: 5m
 ```
 
 # How to add new bases

--- a/common/daemonset.yaml.tmpl
+++ b/common/daemonset.yaml.tmpl
@@ -1,0 +1,29 @@
+# PROMETHEUS RULES
+# DO NOT REMOVE line above, used in `pre-commit` hook
+
+groups:
+  - name: MissingDaemonSetReplicas
+    rules:
+      - alert: DaemonsetMissingReplicas
+        # Alert if there are unhealthy replicas and the ds is not updating it's replicas
+        expr: ((kube_daemonset_status_number_ready != kube_daemonset_status_desired_number_scheduled) and (changes(kube_daemonset_status_updated_number_scheduled[10m]) == 0)) * on (namespace) group_left(team) uw_namespace_oncall_team
+        for: $NODE_ROLL_WINDOW
+        labels:
+          team: infra
+          alertgroup: missing_replicas
+        annotations:
+          summary: "Daemonset {{$labels.namespace}}/{{$labels.daemonset}} has missing replicas"
+          impact: "Workload unavailable on some nodes"
+          action: "Check why some replicas are not healthy"
+          command: "kubectl --context $ENVIRONMENT-$PROVIDER --namespace {{ $labels.namespace }} describe daemonset {{ $labels.daemonset }}"
+      - alert: DaemonsetMissingAllReplicas
+        expr: (kube_daemonset_status_number_ready == 0 and kube_daemonset_status_desired_number_scheduled != 0) * on (namespace) group_left(team) uw_namespace_oncall_team
+        for: $NODE_ROLL_WINDOW
+        labels:
+          team: infra
+          alertgroup: missing_replicas
+        annotations:
+          summary: "Daemonset {{$labels.namespace}}/{{$labels.daemonset}} has 0 healthy replicas."
+          impact: "Workload is down"
+          action: "Check why all replicas are missing"
+          command: "kubectl --context $ENVIRONMENT-$PROVIDER --namespace {{ $labels.namespace }} describe daemonset {{ $labels.daemonset }}"

--- a/common/kustomization.yaml
+++ b/common/kustomization.yaml
@@ -5,6 +5,7 @@ configMapGenerator:
   - files:
       - all.yaml.tmpl=all.yaml.tmpl
       - canary.yaml
+      - daemonset.yaml.tmpl=daemonset.yaml.tmpl
       - logging.yaml.tmpl=logging.yaml.tmpl
       - vault.yaml.tmpl
 

--- a/common/stock/missing_replicas.yaml.tmpl
+++ b/common/stock/missing_replicas.yaml.tmpl
@@ -26,18 +26,6 @@ groups:
           impact: "Workload may be unavailable or have lost high availability"
           action: "Check why some replicas are not healthy"
           command: "kubectl --context $ENVIRONMENT-$PROVIDER --namespace {{ $labels.namespace }} describe statefulset {{ $labels.statefulset }}"
-      - alert: DaemonsetMissingReplicas
-        # Alert if there are unhealthy replicas and the ds is not updating it's replicas
-        expr: ((kube_daemonset_status_number_ready != kube_daemonset_status_desired_number_scheduled) and (changes(kube_daemonset_status_updated_number_scheduled[10m]) == 0)) * on (namespace) group_left(team) uw_namespace_oncall_team
-        for: 5m
-        labels:
-          alerttype: stock
-          alertgroup: missing_replicas
-        annotations:
-          summary: "Daemonset {{$labels.namespace}}/{{$labels.daemonset}} has missing replicas"
-          impact: "Workload unavailable on some nodes"
-          action: "Check why some replicas are not healthy"
-          command: "kubectl --context $ENVIRONMENT-$PROVIDER --namespace {{ $labels.namespace }} describe daemonset {{ $labels.daemonset }}"
       - alert: DeploymentMissingAllReplicas
         expr: (kube_deployment_status_replicas_available == 0 and kube_deployment_status_replicas != 0) * ON (deployment, namespace) group_left(annotation_app_uw_systems_tier, annotation_app_uw_systems_system, annotation_app_uw_systems_owner) kube_deployment_annotations * on (namespace) group_left(team) uw_namespace_oncall_team
         for: 5m
@@ -60,14 +48,3 @@ groups:
           impact: "Workload is down"
           action: "Check why all replicas are missing"
           command: "kubectl --context $ENVIRONMENT-$PROVIDER --namespace {{ $labels.namespace }} describe statefulset {{ $labels.statefulset }}"
-      - alert: DaemonsetMissingAllReplicas
-        expr: (kube_daemonset_status_number_ready == 0 and kube_daemonset_status_desired_number_scheduled != 0) * on (namespace) group_left(team) uw_namespace_oncall_team
-        for: 5m
-        labels:
-          alerttype: stock
-          alertgroup: missing_replicas
-        annotations:
-          summary: "Daemonset {{$labels.namespace}}/{{$labels.daemonset}} has 0 healthy replicas."
-          impact: "Workload is down"
-          action: "Check why all replicas are missing"
-          command: "kubectl --context $ENVIRONMENT-$PROVIDER --namespace {{ $labels.namespace }} describe daemonset {{ $labels.daemonset }}"


### PR DESCRIPTION
Removes DS alerts from stock alerts as no team should really need to run any daemonset under their namespaces (arguably should not even be allowed to). Also, make the time window before firing configurable so we can raise it for clusters like on prem where we need more time to reboot nodes.