### PR TITLE
[DENA-512] add cockroachdb stock alerts

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,4 @@
 *                                      @utilitywarehouse/system
 
 common/stock/elasticsearch.yaml.tmpl   @utilitywarehouse/dev-enablement @utilitywarehouse/system
+common/stock/cockroachdb.yaml.tmpl   @utilitywarehouse/dev-enablement @utilitywarehouse/system

--- a/common/kustomization.yaml
+++ b/common/kustomization.yaml
@@ -11,6 +11,7 @@ configMapGenerator:
       - metrics.yaml.tmpl
       - vault.yaml.tmpl
 
+      - stock/cockroachdb.yaml.tmpl
       - stock/container.yaml.tmpl
       - stock/elasticsearch.yaml.tmpl
       - stock/missing_replicas.yaml.tmpl

--- a/common/stock/cockroachdb.yaml.tmpl
+++ b/common/stock/cockroachdb.yaml.tmpl
@@ -1,0 +1,64 @@
+groups:
+  - name: CockroachDB
+    rules:
+      - alert: CockroachdbQueriesErroring
+        expr: (sum(label_replace(rate(sql_failure_count[10m]),  "namespace", "$1", "kubernetes_namespace", "(.*)")) by (namespace, app) > 0)  * on (namespace) group_left(team) uw_namespace_oncall_team
+        labels:
+          alerttype: stock
+          alertgroup: cockroachdb
+        annotations:
+          summary: "CockroachDB cluster {{$labels.app}} in namespace {{$labels.namespace}} reports query failures"
+          impact: "Some of the queries are failing"
+          action: "Use the Insights page to find failed executions and modify the queries"
+      - alert: CockroachdbWriteStalls
+        expr: (sum(label_replace(rate(storage_write_stalls[10m]),  "namespace", "$1", "kubernetes_namespace", "(.*)")) by (namespace, app) > 0)  * on (namespace) group_left(team) uw_namespace_oncall_team
+        labels:
+          alerttype: stock
+          alertgroup: cockroachdb
+        annotations:
+          summary: "CockroachDB cluster {{$labels.app}} in namespace {{$labels.namespace}} reports write stalls"
+          impact: "Bad cluster performance, node liveness issues"
+          action: "Check the storage hard drives"
+          link: "https://www.cockroachlabs.com/docs/stable/cluster-setup-troubleshooting#disk-stalls"
+      - alert: CockroachdbRangesUnderreplicated
+        expr: (sum(label_replace(ranges_underreplicated,  "namespace", "$1", "kubernetes_namespace", "(.*)")) by (namespace, app) > 1)  * on (namespace) group_left(team) uw_namespace_oncall_team
+        for: 15m
+        labels:
+          alerttype: stock
+          alertgroup: cockroachdb
+        annotations:
+          summary: "CockroachDB cluster {{$labels.app}} in namespace {{$labels.namespace}} reports that some ranges doesn't have enough replicas"
+          impact: "reduced fault tolerance, increased read/ write latency"
+          action: "See replication dashboard, check if there is there enough nodes in the cluster"
+          link: "https://www.cockroachlabs.com/docs/v24.1/cluster-setup-troubleshooting#replication-issues"
+      - alert: CockroachdbRangesUnavailable
+        expr: (sum(label_replace(ranges_unavailable,  "namespace", "$1", "kubernetes_namespace", "(.*)")) by (namespace, app) > 1)  * on (namespace) group_left(team) uw_namespace_oncall_team
+        for: 15m
+        labels:
+          alerttype: stock
+          alertgroup: cockroachdb
+        annotations:
+          summary: "CockroachDB cluster {{$labels.app}} in namespace {{$labels.namespace}} cannot access some chunks of data"
+          impact: "Data inaccessibility"
+          action: "See replication dashboard, check if there is there enough nodes in the cluster"
+          link: "https://www.cockroachlabs.com/docs/v24.1/cluster-setup-troubleshooting#replication-issues"
+      - alert: CockroachdbAdmissionOverload
+        expr: (sum(label_replace(admission_io_overload,  "namespace", "$1", "kubernetes_namespace", "(.*)")) by (namespace, app) > 0.8)  * on (namespace) group_left(team) uw_namespace_oncall_team
+        labels:
+          alerttype: stock
+          alertgroup: cockroachdb
+        annotations:
+          summary: "CockroachDB cluster {{$labels.app}} in namespace {{$labels.namespace}} is close to admission overload"
+          impact: "increased latency, query rejections"
+          action: "Check the cluster resources"
+          link: "https://www.cockroachlabs.com/blog/admission-control-unexpected-overload/"
+      - alert: CockroachdbContentionConflicts
+        expr: (sum(label_replace(rate(txn_restarts_sum[10m]),  "namespace", "$1", "kubernetes_namespace", "(.*)")) by (namespace, app) > 10)  * on (namespace) group_left(team) uw_namespace_oncall_team
+        labels:
+          alerttype: stock
+          alertgroup: cockroachdb
+        annotations:
+          summary: "CockroachDB cluster {{$labels.app}} in namespace {{$labels.namespace}} reports high level of transaction restarts due to contention"
+          impact: "increased latency, increased resource usage"
+          action: "https://www.cockroachlabs.com/docs/v24.1/performance-best-practices-overview#reduce-transaction-contention"
+          link: "https://www.cockroachlabs.com/docs/v24.1/performance-best-practices-overview#transaction-contention"

--- a/common/stock/cockroachdb.yaml.tmpl
+++ b/common/stock/cockroachdb.yaml.tmpl
@@ -10,6 +10,7 @@ groups:
           summary: "CockroachDB cluster {{$labels.app}} in namespace {{$labels.namespace}} reports query failures"
           impact: "Some of the queries are failing"
           action: "Use the Insights page to find failed executions and modify the queries"
+          dashboard: <https://grafana.$ENVIRONMENT.$PROVIDER.uw.systems/d/ddnrjgg8eby80e/cockroachdb-overview?orgId=1&refresh=1m&from=now-12h&to=now&var-instance={{$labels.app}}&var-namespace={{ $labels.namespace }}|link>
       - alert: CockroachdbWriteStalls
         expr: (sum(label_replace(rate(storage_write_stalls[10m]),  "namespace", "$1", "kubernetes_namespace", "(.*)")) by (namespace, app) > 0)  * on (namespace) group_left(team) uw_namespace_oncall_team
         labels:
@@ -20,6 +21,7 @@ groups:
           impact: "Bad cluster performance, node liveness issues"
           action: "Check the storage hard drives"
           link: "https://www.cockroachlabs.com/docs/stable/cluster-setup-troubleshooting#disk-stalls"
+          dashboard: <https://grafana.$ENVIRONMENT.$PROVIDER.uw.systems/d/ddnrjgg8eby80e/cockroachdb-overview?orgId=1&refresh=1m&from=now-12h&to=now&var-instance={{$labels.app}}&var-namespace={{ $labels.namespace }}|link>
       - alert: CockroachdbRangesUnderreplicated
         expr: (sum(label_replace(ranges_underreplicated,  "namespace", "$1", "kubernetes_namespace", "(.*)")) by (namespace, app) > 1)  * on (namespace) group_left(team) uw_namespace_oncall_team
         for: 15m
@@ -31,6 +33,7 @@ groups:
           impact: "reduced fault tolerance, increased read/ write latency"
           action: "See the replication dashboard, check if there are enough nodes in the cluster"
           link: "https://www.cockroachlabs.com/docs/v24.1/cluster-setup-troubleshooting#replication-issues"
+          dashboard: <https://grafana.$ENVIRONMENT.$PROVIDER.uw.systems/d/ddnrjgg8eby80e/cockroachdb-overview?orgId=1&refresh=1m&from=now-12h&to=now&var-instance={{$labels.app}}&var-namespace={{ $labels.namespace }}|link>
       - alert: CockroachdbRangesUnavailable
         expr: (sum(label_replace(ranges_unavailable,  "namespace", "$1", "kubernetes_namespace", "(.*)")) by (namespace, app) > 1)  * on (namespace) group_left(team) uw_namespace_oncall_team
         for: 15m
@@ -42,6 +45,7 @@ groups:
           impact: "Data inaccessibility"
           action: "See the replication dashboard, check if there are enough nodes in the cluster"
           link: "https://www.cockroachlabs.com/docs/v24.1/cluster-setup-troubleshooting#replication-issues"
+          dashboard: <https://grafana.$ENVIRONMENT.$PROVIDER.uw.systems/d/ddnrjgg8eby80e/cockroachdb-overview?orgId=1&refresh=1m&from=now-12h&to=now&var-instance={{$labels.app}}&var-namespace={{ $labels.namespace }}|link>
       - alert: CockroachdbAdmissionOverload
         expr: (sum(label_replace(admission_io_overload,  "namespace", "$1", "kubernetes_namespace", "(.*)")) by (namespace, app) > 0.8)  * on (namespace) group_left(team) uw_namespace_oncall_team
         labels:
@@ -52,6 +56,7 @@ groups:
           impact: "increased latency, query rejections"
           action: "Check the cluster resources"
           link: "https://www.cockroachlabs.com/blog/admission-control-unexpected-overload/"
+          dashboard: <https://grafana.$ENVIRONMENT.$PROVIDER.uw.systems/d/ddnrjgg8eby80e/cockroachdb-overview?orgId=1&refresh=1m&from=now-12h&to=now&var-instance={{$labels.app}}&var-namespace={{ $labels.namespace }}|link>
       - alert: CockroachdbContentionConflicts
         expr: (sum(label_replace(rate(txn_restarts_sum[10m]),  "namespace", "$1", "kubernetes_namespace", "(.*)")) by (namespace, app) > 10)  * on (namespace) group_left(team) uw_namespace_oncall_team
         labels:
@@ -62,3 +67,4 @@ groups:
           impact: "increased latency, increased resource usage"
           action: "https://www.cockroachlabs.com/docs/v24.1/performance-best-practices-overview#reduce-transaction-contention"
           link: "https://www.cockroachlabs.com/docs/v24.1/performance-best-practices-overview#transaction-contention"
+          dashboard: <https://grafana.$ENVIRONMENT.$PROVIDER.uw.systems/d/ddnrjgg8eby80e/cockroachdb-overview?orgId=1&refresh=1m&from=now-12h&to=now&var-instance={{$labels.app}}&var-namespace={{ $labels.namespace }}|link>

--- a/common/stock/cockroachdb.yaml.tmpl
+++ b/common/stock/cockroachdb.yaml.tmpl
@@ -29,7 +29,7 @@ groups:
         annotations:
           summary: "CockroachDB cluster {{$labels.app}} in namespace {{$labels.namespace}} reports that some ranges doesn't have enough replicas"
           impact: "reduced fault tolerance, increased read/ write latency"
-          action: "See replication dashboard, check if there is there enough nodes in the cluster"
+          action: "See the replication dashboard, check if there are enough nodes in the cluster"
           link: "https://www.cockroachlabs.com/docs/v24.1/cluster-setup-troubleshooting#replication-issues"
       - alert: CockroachdbRangesUnavailable
         expr: (sum(label_replace(ranges_unavailable,  "namespace", "$1", "kubernetes_namespace", "(.*)")) by (namespace, app) > 1)  * on (namespace) group_left(team) uw_namespace_oncall_team
@@ -40,7 +40,7 @@ groups:
         annotations:
           summary: "CockroachDB cluster {{$labels.app}} in namespace {{$labels.namespace}} cannot access some chunks of data"
           impact: "Data inaccessibility"
-          action: "See replication dashboard, check if there is there enough nodes in the cluster"
+          action: "See the replication dashboard, check if there are enough nodes in the cluster"
           link: "https://www.cockroachlabs.com/docs/v24.1/cluster-setup-troubleshooting#replication-issues"
       - alert: CockroachdbAdmissionOverload
         expr: (sum(label_replace(admission_io_overload,  "namespace", "$1", "kubernetes_namespace", "(.*)")) by (namespace, app) > 0.8)  * on (namespace) group_left(team) uw_namespace_oncall_team


### PR DESCRIPTION
I wrote the queries myself, since [example cockroachdb alerts](https://github.com/cockroachdb/cockroach/blob/master/monitoring/rules/alerts.rules.yml) are mostly covered by our container stock alerts.