### PR TITLE
Adapt vector alerts to work if grouped

### DIFF
--- a/common/logging.yaml.tmpl
+++ b/common/logging.yaml.tmpl
@@ -88,9 +88,11 @@ groups:
         annotations:
           summary: "Vector cannot talk to loki"
           description: "Vector's loki buffer is full, which means that it cannot talk to loki"
+          pod: "{{ $labels.kubernetes_pod_name }}"
           impact: "Vector is not accepting new logs from it's input sources"
           action: "Check if loki is up and if vector can talk to it"
           dashboard: "https://grafana.$ENVIRONMENT.$PROVIDER.uw.systems/d/bdnuhz796molca/vector?var-pod={{ $labels.kubernetes_pod_name }}"
+          dashboard-fallback: "https://grafana.$ENVIRONMENT.$PROVIDER.uw.systems/d/bdnuhz796molca/vector"
       - alert: VectorFailingToInput
         expr: rate(vector_component_received_events_total{component_kind="source",component_id!="vector_metrics"}[5m]) == 0
         for: 15m
@@ -98,5 +100,7 @@ groups:
           team: infra
         annotations:
           summary: "Vector is not receiving logs"
-          description: "{{ $labels.kubernetes_pod_name }} received no logs from {{ $labels.component_id }} for 15m"
+          description: "Vector received no logs from {{ $labels.component_id }} for 15m"
+          pod: "{{ $labels.kubernetes_pod_name }}"
           dashboard: "https://grafana.$ENVIRONMENT.$PROVIDER.uw.systems/d/bdnuhz796molca/vector?var-pod={{ $labels.kubernetes_pod_name }}"
+          dashboard-fallback: "https://grafana.$ENVIRONMENT.$PROVIDER.uw.systems/d/bdnuhz796molca/vector"


### PR DESCRIPTION
When grouped, pod name is not available, so annotations with it will error and not appear. Ensure that a description and a dashboard is always available.