### PR TITLE
Remove VectorFailingToInput alert

### DIFF
--- a/common/logging.yaml.tmpl
+++ b/common/logging.yaml.tmpl
@@ -93,17 +93,6 @@ groups:
           action: "Check if loki is up and if vector can talk to it"
           dashboard: "https://grafana.$ENVIRONMENT.$PROVIDER.uw.systems/d/bdnuhz796molca/vector?var-pod={{ $labels.kubernetes_pod_name }}"
           dashboard_fallback: "https://grafana.$ENVIRONMENT.$PROVIDER.uw.systems/d/bdnuhz796molca/vector"
-      - alert: VectorFailingToInput
-        expr: rate(vector_component_received_events_total{component_kind="source",component_id!="vector_metrics"}[5m]) == 0
-        for: 15m
-        labels:
-          team: infra
-        annotations:
-          summary: "Vector is not receiving logs"
-          description: "Vector received no logs from {{ $labels.component_id }} for 15m"
-          pod: "{{ $labels.kubernetes_pod_name }}"
-          dashboard: "https://grafana.$ENVIRONMENT.$PROVIDER.uw.systems/d/bdnuhz796molca/vector?var-pod={{ $labels.kubernetes_pod_name }}"
-          dashboard_fallback: "https://grafana.$ENVIRONMENT.$PROVIDER.uw.systems/d/bdnuhz796molca/vector"
       - alert: VectorComponentErroring
         expr: rate(vector_component_errors_total[5m]) > 0
         for: 15m


### PR DESCRIPTION
The alert is too generic given how different input sources work. Some only run on some nodes, and some have so little input that it's ok to be 0 for a long time (like falco alerts on gcp or merit).

This should be replaced by specific alerts per input source, considering it's expected input rates, if any.