### PR TITLE
Relax volume filling up alerts

### DIFF
--- a/common/stock/storage.yaml.tmpl
+++ b/common/stock/storage.yaml.tmpl
@@ -5,7 +5,7 @@ groups:
   - name: Storage
     rules:
       - alert: VolumeFillingUpin72h
-        expr: ((predict_linear(kubelet_volume_stats_available_bytes[1h], 72 * 3600) < 0) and (kubelet_volume_stats_used_bytes / kubelet_volume_stats_capacity_bytes > 0.5)) * on (namespace) group_left(team) uw_namespace_oncall_team
+        expr: ((predict_linear(kubelet_volume_stats_available_bytes[1h], 72 * 3600) < 0) and (kubelet_volume_stats_used_bytes / kubelet_volume_stats_capacity_bytes > 0.7)) * on (namespace) group_left(team) uw_namespace_oncall_team
         for: 2h
         labels:
           alerttype: stock
@@ -17,7 +17,7 @@ groups:
           runbook: "https://wiki.uw.systems/posts/how-to-resize-a-stateful-set-volume-claim-1svb2nvt"
           dashboard: <https://grafana.$ENVIRONMENT.$PROVIDER.uw.systems/d/919b92a8e8041bd567af9edab12c840c/kubernetes-persistent-volumes?orgId=1&refresh=10s&var-datasource=default&var-cluster=${ENVIRONMENT}-${PROVIDER}&var-namespace={{ $labels.namespace }}&var-volume={{ $labels.persistentvolumeclaim }}|link>
       - alert: VolumeFillingUpin6h
-        expr: ((predict_linear(kubelet_volume_stats_available_bytes[1h], 6 * 3600) < 0) and (kubelet_volume_stats_used_bytes / kubelet_volume_stats_capacity_bytes > 0.5)) * on (namespace) group_left(team) uw_namespace_oncall_team
+        expr: ((predict_linear(kubelet_volume_stats_available_bytes[1h], 6 * 3600) < 0) and (kubelet_volume_stats_used_bytes / kubelet_volume_stats_capacity_bytes > 0.7)) * on (namespace) group_left(team) uw_namespace_oncall_team
         for: 30m
         labels:
           alerttype: stock


### PR DESCRIPTION
Increase the volume usage requirement to 70% to allow disk usage bursts under that disk usage levels.