### PR TITLE
Increase tolerance for missing RDS metrics

### DIFF
--- a/rds/system-alerts.yaml.tmpl
+++ b/rds/system-alerts.yaml.tmpl
@@ -6,7 +6,7 @@ groups:
     rules:
       - alert: RDSExporterMissingMetrics
         expr: absent(rds_exporter_build_info)
-        for: 5m
+        for: 15m
         labels:
           team: infra
         annotations:


### PR DESCRIPTION
We're gonna scrape at 5 minutes interval the RDS exporter through an individual configured job. 
So give it a change to fail twice.