### PR TITLE
msk dev: adapt the supported number of partitions after scaling up

### DIFF
--- a/pubsub-msk-dev/msk.yaml.tmpl
+++ b/pubsub-msk-dev/msk.yaml.tmpl
@@ -5,7 +5,7 @@ groups:
   - name: pubsub-msk
     rules:
       - alert: MSKSharedPartitionsLimit
-        expr: kafka_server_ReplicaManager_Value{name="PartitionCount", job="msk-shared"} >= 950
+        expr: kafka_server_ReplicaManager_Value{name="PartitionCount", job="msk-shared"} >= 1950
         labels:
           team: infra
           group: kafka


### PR DESCRIPTION
Went to 2xLarge that support 2000 partitions/node