### PR TITLE
msk backup: add alert for task stopping.

### DIFF
--- a/pubsub-msk/msk-backup.yaml.tmpl
+++ b/pubsub-msk/msk-backup.yaml.tmpl
@@ -1,0 +1,20 @@
+# PROMETHEUS RULES
+# DO NOT REMOVE line above, used in `pre-commit` hook
+
+groups:
+  - name: msk-backup
+    rules:
+      - alert: MSKBackupTaskStopped
+        # This expression is temporary until we figure out metrics from the connect task itself.
+        # It is not ideal, as we're alerting if the backup connector hasn't consumed anything for an hour, which may be because no app has produced on any topic for 1h.
+        # Checked the query so far, and it picked up only the periods when the task stopped due to connector issue.
+        expr: sum(rate(kafka_consumergroup_current_offset{consumergroup="pubsub.msk-backup-kafka-connect"}[60m])) == 0
+        labels:
+          team: infra
+          group: kafka
+        annotations:
+          summary: "The MSK backup task has stopped"
+          impact: "The MSK topics are not being backed up"
+          dashboard: "https://kafka-ui.$ENVIRONMENT.uw.systems/ui/clusters/shared-msk/connects/msk-backup-connect/connectors/msk-s3-backup-sink-all-parquet"
+          doc: "https://wiki.uw.systems/posts/shared-kafka-on-aws-msk-runbook-10pijp5z#ht59o-msk-data-backup"
+          action: "Check the source error in the UI. Restart the task from the UI"


### PR DESCRIPTION
Alert on a not perferct expression, so at least we're aware that it stopped.

Not much meat on the action for now